### PR TITLE
Update cover.py

### DIFF
--- a/custom_components/netatmo/cover.py
+++ b/custom_components/netatmo/cover.py
@@ -152,7 +152,7 @@ class NetatmoCover(NetatmoBase, CoverEntity):
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover shutter to a specific position."""
-        await self._cover.async_set_target_position(100 - kwargs[ATTR_POSITION])
+        await self._cover.async_set_target_position(kwargs[ATTR_POSITION])
 
     @property
     def device_class(self) -> str:


### PR DESCRIPTION
when setting the position (through the slider for instance), number should not be inverted.
![image](https://user-images.githubusercontent.com/5701372/159372076-6686f987-2394-44e8-bf47-6f74e602c358.png)
where 0 is closed.